### PR TITLE
Fix printing in resize script

### DIFF
--- a/scripts/resize_assets.py
+++ b/scripts/resize_assets.py
@@ -17,8 +17,9 @@ def batch_resize():
 
         try:
             resize_image(input_path, output_size, crop_mode)
-            print(f"Successfully resized {input_path} to {
-                  output_size[0]}x{output_size[1]}")
+            print(
+                f"Successfully resized {input_path} to {output_size[0]}x{output_size[1]}"
+            )
         except Exception as e:
             print(f"Error resizing {input_path}: {str(e)}")
 


### PR DESCRIPTION
## Summary
- fix formatting of asset resizing output message

## Testing
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688791d7dd00832bb5996bd1cdecd8ff